### PR TITLE
Wrong look up on klass.class.name

### DIFF
--- a/lib/minitest/retry.rb
+++ b/lib/minitest/retry.rb
@@ -74,7 +74,7 @@ module Minitest
 
         result = super(klass, method_name)
 
-        klass_method_name = "#{klass.class.name}##{method_name}"
+        klass_method_name = "#{klass.name}##{method_name}"
         return result unless Minitest::Retry.failure_to_retry?(result.failures, klass_method_name)
         if !result.skipped?
           Minitest::Retry.failure_callback.call(klass, method_name, result) if Minitest::Retry.failure_callback

--- a/test/minitest/retry_test.rb
+++ b/test/minitest/retry_test.rb
@@ -190,10 +190,17 @@ class Minitest::RetryTest < Minitest::Test
     capture_stdout do
       retry_test = Class.new(Minitest::Test) do
         @@counter = 0
+
+        class << self
+          def name
+            'TestClass'
+          end
+        end
+
         def self.counter
           @@counter
         end
-        Minitest::Retry.use! methods_to_retry: ["#{self.class.name}#fail"]
+        Minitest::Retry.use! methods_to_retry: ["TestClass#fail"]
         def fail
           @@counter += 1;
           assert false, 'fail test'
@@ -209,10 +216,17 @@ class Minitest::RetryTest < Minitest::Test
     capture_stdout do
       retry_test = Class.new(Minitest::Test) do
         @@counter = 0
+
+        class << self
+          def name
+            'TestClass'
+          end
+        end
+
         def self.counter
           @@counter
         end
-        Minitest::Retry.use! methods_to_retry: ["#{self.class.name}#fail"]
+        Minitest::Retry.use! methods_to_retry: ["TestClass#fail"]
         def another_fail
           @@counter += 1;
           assert false, 'fail test'


### PR DESCRIPTION
The 'class' is not necessary there. It was for test, but
now the tests have been updated to behave like a regular class.